### PR TITLE
bug fix for the example

### DIFF
--- a/examples/using_sympy_provider_level_1.py
+++ b/examples/using_sympy_provider_level_1.py
@@ -50,7 +50,9 @@ qobj = compile([qc1, qc2], backend=statevector_backend)
 
 # Running the both backends on the same qobj
 statevector_job = statevector_backend.run(qobj)
-unitary_job = unitary_backend.run(qobj)
+
+qobj2 = compile([qc1, qc2], backend=unitary_backend)
+unitary_job = unitary_backend.run(qobj2)
 
 lapse = 0
 interval = 0.01


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR is requested for fixing a bug in using_sympy_provider_level_1.py.

instead of using:
unitary_job = unitary_backend.run(qobj) 
we shall use:
qobj2 = compile([qc1, qc2], backend=unitary_backend) 
unitary_job = unitary_backend.run(qobj2)

the previous code can lead to the following validation exception. 
The reason is that unitary_backend was used to run the qobj that specifies statevector_backend as the backend.





### Details and comments


Traceback (most recent call last):
  File "/Users/liup/quantum/qiskit-sympy-provider/examples/using_sympy_provider_level_1.py", line 55, in <module>
    unitary_job = unitary_backend.run(qobj)
  File "/Users/liup/quantum/qiskit-sympy-provider/qiskit_addon_sympy/unitary_simulator.py", line 183, in run
    sym_job.submit()
  File "/Users/liup/quantum/qiskit-sympy-provider/qiskit_addon_sympy/sympyjob.py", line 70, in submit
    validate_qobj_against_schema(self._qobj)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/qiskit/qobj/_validation.py", line 22, in validate_qobj_against_schema
    err_msg='Qobj failed validation. '
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/qiskit/_schema_validation.py", line 149, in validate_json_against_schema
    raise newerr
qiskit._schema_validation.SchemaValidationError: 'Qobj failed validation. Set Qiskit log level to DEBUG for further information.'

Process finished with exit code 1
